### PR TITLE
Fix bobZkSyncWallet to match answer validation

### DIFF
--- a/en/17/11.md
+++ b/en/17/11.md
@@ -194,4 +194,4 @@ console.log(`Bob's initial balance on Rinkeby is: ${ethers.utils.formatEther(awa
   * The first parameter should be Bob's private key, you can grab it from the `process.env.BOB_PRIVATE_KEY` environment variable
   * The name of the `const` variable used to store the wallet should be `bobRinkebyWallet`.
 2. Show Bob's address on Rinkeby and his initial balance.
-3. Before we wrap up this chapter, let's create a zkSync wallet for Bob. Declare a `const` variable named `bobZkSync` wallet, and set it to `await utils.initAccount(bobRinkebyWallet, zkSyncProvider, zksync)`
+3. Before we wrap up this chapter, let's create a zkSync wallet for Bob. Declare a `const` variable named `bobZkSyncWallet`, and set it to `await utils.initAccount(bobRinkebyWallet, zkSyncProvider, zksync)`


### PR DESCRIPTION
Localized by the url [https://cryptozombies.io/en/lesson/17/chapter/11](https://cryptozombies.io/en/lesson/17/chapter/11).

At the end of the page the variable `bobZkSync` doesn't match the answer validation which is `bobZkSyncWallet`

- [ ] I did these translations myself and own copyright for them
- [ ] I didn't use a machine to do these translations
- [ ] I assign all copyright to Loom Network for these translations
